### PR TITLE
Fix Vercel deployment error and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# DroidX API
+
+A high-performance, production-grade API for accessing F-Droid repository data. Features unlimited requests, full CORS support, and millisecond response times.
+
+## Features
+
+- **No Rate Limits:** Unlimited requests for all endpoints.
+- **Full CORS Support:** Access the API from any origin.
+- **High Performance:** Sub-millisecond response times for most queries.
+- **Comprehensive Error Handling:** Standardized error responses.
+- **Daily Updates:** Application data is updated automatically every day.
+- **Production-Ready:** Built for reliability and scalability.
+
+## API Endpoints
+
+Here is a list of available endpoints:
+
+| Method | Endpoint                  | Description                                |
+|--------|---------------------------|--------------------------------------------|
+| GET    | `/`                       | Get API documentation and endpoint list.   |
+| GET    | `/health`                 | Check the health status of the API.        |
+| GET    | `/apps`                   | Get all applications (excluding games).    |
+| GET    | `/games`                  | Get all game applications.                 |
+| GET    | `/all`                    | Get a complete list of all apps and games. |
+| GET    | `/app/<app_id>`           | Get details for a specific application.    |
+| GET    | `/search?q=<query>`       | Search for applications.                   |
+| GET    | `/categories`             | Get a list of all categories with counts.  |
+| GET    | `/category/<name>`        | Get all apps in a specific category.       |
+| GET    | `/latest?limit=<n>`       | Get the most recently updated applications.|
+| GET    | `/random`                 | Get a random application.                  |
+| GET    | `/stats`                  | Get repository statistics.                 |
+
+## Basic Usage
+
+### Get all apps
+```bash
+curl https://your-api-domain/apps
+```
+
+### Search for an app
+```bash
+curl https://your-api-domain/search?q=File%20Manager
+```
+
+### Get a specific app
+```bash
+curl https://your-api-domain/app/com.simplemobiletools.filemanager.pro
+```

--- a/api/index.py
+++ b/api/index.py
@@ -51,7 +51,7 @@ CORS(app, resources={
 
 class Config:
     """Application configuration"""
-    DATA_FILE = os.path.join('data', 'apps.json')
+    DATA_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'apps.json'))
     API_VERSION = '1.0.0'
     API_NAME = 'DroidX'
     MAX_SEARCH_RESULTS = None

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,8 @@
       "use": "@vercel/python",
       "config": {
         "maxDuration": 30,
-        "memory": 1024
+        "memory": 1024,
+        "includeFiles": "data/apps.json"
       }
     }
   ],


### PR DESCRIPTION
This commit addresses a `FUNCTION_INVOCATION_FAILED` error on Vercel by ensuring the `data/apps.json` file is included in the build and accessible at runtime.

- Update `vercel.json` to include `data/apps.json` in the serverless function's build using the `includeFiles` property.
- Modify `api/index.py` to use an absolute path for the data file, making file access more robust.
- Add a comprehensive `README.md` file with project documentation, including features, API endpoints, and usage examples.